### PR TITLE
Fix auth middleware bug

### DIFF
--- a/server/src/controllers/users/insertUserController.js
+++ b/server/src/controllers/users/insertUserController.js
@@ -2,7 +2,7 @@
 const insertUserModel = require('../../models/users/insertUserModel');
 
 // Importar funciones de manejo de errores
-const { errorController } = require('../../services/errorService');
+const { missingFieldsError } = require('../../services/errorService');
 
 // Crear la función del controlador para manejar la lógica principal
 const insertUserController = async (req, res, next) => {
@@ -12,7 +12,7 @@ const insertUserController = async (req, res, next) => {
 
         // Validar los datos utilizando Joi u otro método de validación
         if (!username || !email || !password) {
-            errorController();
+            missingFieldsError();
         }
 
         // Insertar al usuario

--- a/server/src/controllers/users/loginUsersController.js
+++ b/server/src/controllers/users/loginUsersController.js
@@ -1,7 +1,7 @@
 const jwt = require('jsonwebtoken');
 
 // Importar funciones de manejo de errores
-const { errorController, invalidCredentialsError } = require('../../services/errorService');
+const { missingFieldsError, invalidCredentialsError } = require('../../services/errorService');
 
 // Importar bcrypt para el cifrado de contraseñas
 const bcrypt = require('bcrypt');
@@ -15,7 +15,7 @@ const loginUsersController = async (req, res, next) => {
 
         // Comprobar campos faltantes
         if (!email || !password) {
-            errorController();
+            missingFieldsError();
         }
 
         // Obtener los datos del usuario por correo electrónico

--- a/server/src/middlewares/authUserController.js
+++ b/server/src/middlewares/authUserController.js
@@ -14,7 +14,8 @@ const authUserController = async (req, res, next) => {
         // Obtenemos el token de la cabecera de la petición.
         const { authorization } = req.headers;
         if (!authorization) {
-            notAuthenticatedError; // 
+            // Launch specific error when there is no authorization header
+            notAuthenticatedError();
         }
 
         // Variable que almacenará la información del token desencriptado.

--- a/server/src/services/errorService.js
+++ b/server/src/services/errorService.js
@@ -27,6 +27,13 @@ module.exports = {
             message: 'Primero incia sesion',
         };
     },
+    missingFieldsError() {
+        throw {
+            httpStatus: 400, // Bad request
+            code: 'MISSING_FIELDS',
+            message: 'Faltan campos obligatorios',
+        };
+    },
     likeAlreadyExistsError() {
         throw {
             httpStatus: 409, // Conflict

--- a/server/src/utils/deletePhotoUtil.js
+++ b/server/src/utils/deletePhotoUtil.js
@@ -26,7 +26,7 @@ const deletePhotoUtil = async (imgName, width) => {
         await fs.unlink(imgPath);
     } catch (err) {
         console.error(err);
-        deleteFileError;
+        deleteFileError();
     }
 };
 

--- a/server/src/utils/savePhotoUtil.js
+++ b/server/src/utils/savePhotoUtil.js
@@ -42,7 +42,7 @@ const savePhotoUtil = async (img, width) => {
         return imgName;
     } catch (err) {
         console.error(err);
-        saveFileError;
+        saveFileError();
     }
 };
 


### PR DESCRIPTION
## Summary
- ensure `notAuthenticatedError()` is called when auth header is missing
- add missing fields error helper
- replace wrong error usage in user controllers
- trigger file util errors correctly

## Testing
- `node -e "const s=require('./server/src/services/errorService'); console.log(Object.keys(s));"`
- `node - <<'NODE'
const {missingFieldsError} = require('./server/src/services/errorService');
try{missingFieldsError();}catch(e){console.log(e.code);}
NODE`

------
https://chatgpt.com/codex/tasks/task_e_6841ff28c20c832f86228739b4281c1b